### PR TITLE
save log output of .initialboot script to /var/log/initialboot

### DIFF
--- a/usr/src/cmd/svc/milestone/initial-boot
+++ b/usr/src/cmd/svc/milestone/initial-boot
@@ -39,7 +39,7 @@ if [ -e "/.initialboot" ]; then
 	echo ". /lib/svc/share/initial_include.sh" >> $SCRIPT
 	cat /.initialboot >> $SCRIPT
 	chmod 550 $SCRIPT
-	$SCRIPT
+	$SCRIPT > /var/log/initialboot
 	rv=$?
 	if [ "$rv" != "$SMF_EXIT_OK" ]; then
 		exit $rv


### PR DESCRIPTION
If any errors pop up while executing the .initialboot file I would like to see them in a log-file to make debugging easier.
