### PR TITLE
only stack pam_unix_session for login-type services

### DIFF
--- a/usr/src/lib/libpam/pam.conf
+++ b/usr/src/lib/libpam/pam.conf
@@ -120,7 +120,11 @@ other	account required	pam_unix_account.so.1
 # Default definition for Session management
 # Used when service name is not explicitly mentioned for session management
 #
-other	session required	pam_unix_session.so.1
+other	session required	pam_allow.so.1
+# pam_unix_session records and reports the last login time, so it should only
+# be stacked for services that are actually logins.
+login	session required	pam_unix_session.so.1
+ssh	session required	pam_unix_session.so.1
 #
 # Default definition for Password management
 # Used when service name is not explicitly mentioned for password management


### PR DESCRIPTION
This should make sudo (and in fact everything except login(1) and ssh) no longer record lastlog.

I might consider upstreaming this later but I have a hunch configuration changes like this are going to be annoying to upstream, so let's just fix it here first.

SUNWcs ships this as preserve=true. Not having pam.d obviously makes it difficult to effect this change on boxes with modified PAM config, but I guess your sudo workaround suffices there.