### PR TITLE
A few more small fixes specific to Xen

### DIFF
--- a/usr/src/uts/common/xen/io/xdf.c
+++ b/usr/src/uts/common/xen/io/xdf.c
@@ -637,10 +637,19 @@ xdf_kstat_exit(xdf_t *vdp, buf_t *bp)
 
 	if (vdp->xdf_xdev_iostat == NULL)
 		return;
+
 	if ((vreq != NULL) && vreq->v_runq) {
 		kstat_runq_exit(KSTAT_IO_PTR(vdp->xdf_xdev_iostat));
 	} else {
 		kstat_waitq_exit(KSTAT_IO_PTR(vdp->xdf_xdev_iostat));
+	}
+
+	if (bp->b_flags & B_READ) {
+		KSTAT_IO_PTR(vdp->xdf_xdev_iostat)->reads++;
+		KSTAT_IO_PTR(vdp->xdf_xdev_iostat)->nread += bp->b_bcount;
+	} else if (bp->b_flags & B_WRITE) {
+		KSTAT_IO_PTR(vdp->xdf_xdev_iostat)->writes++;
+		KSTAT_IO_PTR(vdp->xdf_xdev_iostat)->nwritten += bp->b_bcount;
 	}
 }
 
@@ -3363,7 +3372,7 @@ xdf_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	    HVMPV_XDF_VERS))
 		cmn_err(CE_WARN, "xdf: couldn't write version\n");
 
-#else /* !XPV_HVM_DRIVER */
+#endif /* XPV_HVM_DRIVER */
 
 	/* create kstat for iostat(1M) */
 	if (xdf_kstat_create(dip, "xdf", instance) != 0) {
@@ -3372,7 +3381,6 @@ xdf_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 		goto errout1;
 	}
 
-#endif /* !XPV_HVM_DRIVER */
 
 	ddi_report_dev(dip);
 	DPRINTF(DDI_DBG, ("xdf@%s: attached\n", vdp->xdf_addr));

--- a/usr/src/uts/common/xen/os/xvdi.c
+++ b/usr/src/uts/common/xen/os/xvdi.c
@@ -25,6 +25,10 @@
  */
 
 /*
+ * Copyright (c) 2014 by Delphix. All rights reserved.
+ */
+
+/*
  * Xen virtual device driver interfaces
  */
 
@@ -146,8 +150,10 @@ typedef struct xd_cfg {
 #define	XD_DOM_ALL	(XD_DOM_ZERO | XD_DOM_GUEST)
 
 static i_xd_cfg_t xdci[] = {
+#ifndef XPV_HVM_DRIVER
 	{ XEN_CONSOLE, NULL, NULL, NULL, "xencons", NULL,
 	    "console", IPL_CONS, XD_DOM_ALL, },
+#endif
 
 	{ XEN_VNET, "vif", "device/vif", "backend/vif", "xnf", "xnb",
 	    "network", IPL_VIF, XD_DOM_ALL, },
@@ -158,6 +164,7 @@ static i_xd_cfg_t xdci[] = {
 	{ XEN_BLKTAP, "tap", NULL, "backend/tap", NULL, "xpvtap",
 	    "block", IPL_VBD, XD_DOM_ALL, },
 
+#ifndef XPV_HVM_DRIVER
 	{ XEN_XENBUS, NULL, NULL, NULL, "xenbus", NULL,
 	    NULL, 0, XD_DOM_ALL, },
 
@@ -166,6 +173,7 @@ static i_xd_cfg_t xdci[] = {
 
 	{ XEN_BALLOON, NULL, NULL, NULL, "balloon", NULL,
 	    NULL, 0, XD_DOM_ALL, },
+#endif
 
 	{ XEN_EVTCHN, NULL, NULL, NULL, "evtchn", NULL,
 	    NULL, 0, XD_DOM_ZERO, },

--- a/usr/src/uts/i86pc/i86hvm/io/xpv/evtchn.c
+++ b/usr/src/uts/i86pc/i86hvm/io/xpv/evtchn.c
@@ -24,6 +24,10 @@
  * Use is subject to license terms.
  */
 
+/*
+ * Copyright (c) 2014 by Delphix. All rights reserved.
+ */
+
 #include <sys/types.h>
 #include <sys/xpv_support.h>
 #include <sys/hypervisor.h>
@@ -268,7 +272,7 @@ again:
 		while (pending_word != 0) {
 			j = lowbit(pending_word) - 1;
 			port = (i << EVTCHN_SHIFT) + j;
-			pending_word = pending_word & ~(1 << j);
+			pending_word = pending_word & ~(1UL << j);
 
 			/*
 			 * If there is a handler registered for this event,


### PR DESCRIPTION
@danmcd Here's a few more small fixes specific to running on Xen. It'd be great to get these integrated into an OmniOS ISO so I can try them out on Amazon's EC2.

I recently (earlier today) was able to use the OmniOS "bloody" ISO to create an Amazon EC2 AMI using HVM, but I run into problems due to `diskinfo` reporting the following device information:
```
# diskinfo
TYPE    DISK                    VID      PID              SIZE          RMV SSD
ATA     c1d0                    -        -                  64.00 GiB   no  no
-       c2t0d0                  -        -                  64.00 GiB   no  no
```
but the `rpool` is using `c4t0d0`:
```
# zpool list -v rpool
NAME         SIZE  ALLOC   FREE  EXPANDSZ   FRAG    CAP  DEDUP  HEALTH  ALTROOT
rpool       63.5G  6.60G  56.9G         -     4%    10%  1.00x  ONLINE  -
  c4t0d0    63.5G  6.60G  56.9G         -     4%    10%
```

I'm not certain if these three patches will fix my problem, but I've rolled an OpenIndiana ISO with these patches applied, and on that system, `rpool` reports that it's using the `c2t0d0` as I would expect. If these could be pulled into a "bloody" ISO, I could re-create the EC2 AMI and see if my issue is fixed.

Additionally, this is a problem because when I try and run `onu` on this system, `beadm activate` will fail to update the bootloader because ZFS tells it to install to `/dev/rdsk/c4t0d0`, and that path doesn't actually exist:
```
# export BE_PRINT_ERR=true
# ./usr/src/tools/scripts/onu -t nightly -d ./packages/i386/nightly
...
be_do_installboot: install failed for device c4t0d0.
  Command: "/usr/sbin/installboot -m -f /tmp/onu.JfaWfb/boot/pmbr /tmp/onu.JfaWfb/boot/gptzfsboot /dev/rdsk/c4t0d0s0"
  Errors:
open: No such file or directory
Unable to open device /dev/rdsk/c4t0d0s0
be_run_cmd: command terminated with error status: 1
Unable to activate nightly.
Error installing boot files.
beadm activate nightly failed: exit code 224
```
```
# ls /dev/rdsk/c4*
/dev/rdsk/c4*: No such file or directory
```
Thus, I can't perform a full "nightly" illumos build and then use `onu` to update to that build, which is what I'm trying to accomplish.

It's also worth noting that we've been running with these patches on DelphixOS for nearly 3 years, and haven't run into any problems with them (but I'd like to try and test them on a non-Delphix system before upstreaming to illumos).